### PR TITLE
DCM to quaternion function

### DIFF
--- a/include/Attitude/dcm_to_quaternion.h
+++ b/include/Attitude/dcm_to_quaternion.h
@@ -1,0 +1,29 @@
+/**
+ * @file dcm_to_quaternion.h
+ * @author Michael Wrona
+ * @date 2023-03-26
+ */
+
+#ifndef MATHUTILS_DCM_TO_QUATERNION_H_
+#define MATHUTILS_DCM_TO_QUATERNION_H_
+
+#include "LinAlg/Matrix.h"
+#include "Attitude/Quaternion.h"
+
+namespace MathUtils {
+
+/**
+ * @brief Convert a quaternion to DCM.
+ *
+ * @details "Analytical Mechanics of Aerospace Systems" (Schaub et. al.) Stanley method.
+ *
+ * @param dcm DCM to convert to quaternion.
+ * @return Quaternion corresponding to the DCM.
+ *
+ * @exception std::runtime_error If the DCM could not be converted (something weird happened internally).
+ */
+Quaternion dcm_to_quaternion(const Matrix<3,3>& dcm);
+
+}  // namespace MathUtils
+
+#endif  // MATHUTILS_DCM_TO_QUATERNION_H_

--- a/src/Attitude/dcm_to_quaternion.cpp
+++ b/src/Attitude/dcm_to_quaternion.cpp
@@ -1,0 +1,87 @@
+/**
+ * @file dcm_to_quaternion.cpp
+ * @author Michael Wrona
+ * @date 2023-03-26
+ */
+
+#include "Attitude/dcm_to_quaternion.h"
+#include "float_equality.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <iterator>
+#include <stdexcept>
+
+namespace MathUtils {
+
+Quaternion dcm_to_quaternion(const Matrix<3,3>& dcm)
+{
+  const double dcm_trace = trace(dcm);
+
+  std::array<double, 4> q_squared_terms {
+    0.25 * (1.0 + dcm_trace),
+    0.25 * (1.0 + (2.0 * dcm(0,0)) - dcm_trace),
+    0.25 * (1.0 + (2.0 * dcm(1,1)) - dcm_trace),
+    0.25 * (1.0 + (2.0 * dcm(2,2)) - dcm_trace)
+  };
+
+  // find largest element and its index
+  const auto largest_q_squared_term = std::max_element(q_squared_terms.cbegin(), q_squared_terms.cend());
+  const std::size_t largest_element = std::distance(q_squared_terms.cbegin(), largest_q_squared_term);
+
+  // double check results
+  assert(!float_equality(*largest_q_squared_term, 0.0));
+  assert(*largest_q_squared_term >= 0);
+  assert(largest_element <= 3);  // std::distance can return neg. if inputs are std::distance(end,begin)
+
+  const double largest_q_term = std::sqrt(*largest_q_squared_term);
+
+  // compute the quaternion depending on the largest element
+  switch (largest_element)
+  {
+    case 0:
+    {
+      return Quaternion {
+        largest_q_term,
+        0.25 * (dcm(1,2) - dcm(2,1)) / largest_q_term,
+        0.25 * (dcm(2,0) - dcm(0,2)) / largest_q_term,
+        0.25 * (dcm(0,1) - dcm(1,0)) / largest_q_term
+      };
+    }
+    case 1:
+    {
+      return Quaternion {
+        0.25 * (dcm(1,2) - dcm(2,1)) / largest_q_term,
+        largest_q_term,
+        0.25 * (dcm(0,1) + dcm(1,0)) / largest_q_term,
+        0.25 * (dcm(2,0) + dcm(0,2)) / largest_q_term
+      };
+    }
+    case 2:
+    {
+      return Quaternion {
+        0.25 * (dcm(2,0) - dcm(0,2)) / largest_q_term,
+        0.25 * (dcm(0,1) + dcm(1,0)) / largest_q_term,
+        largest_q_term,
+        0.25 * (dcm(1,2) + dcm(2,1)) / largest_q_term
+      };
+    }
+    case 3:
+    {
+      return Quaternion {
+        0.25 * (dcm(0,1) - dcm(1,0)) / largest_q_term,
+        0.25 * (dcm(2,0) + dcm(0,2)) / largest_q_term,
+        0.25 * (dcm(1,2) + dcm(2,1)) / largest_q_term,
+        largest_q_term
+      };
+    }
+    default:
+    {
+      // should never get here
+      throw std::runtime_error("Error converting DCM to quaternion.");
+    }
+  }
+}
+
+}  // namespace MathUtils

--- a/test/Attitude/test_dcm_to_quaternion.cpp
+++ b/test/Attitude/test_dcm_to_quaternion.cpp
@@ -1,0 +1,130 @@
+/**
+ * @file test_dcm_to_quaternion.cpp
+ * @author Michael Wrona
+ * @date 2023-03-26
+ */
+
+#include "Attitude/Quaternion.h"
+#include "LinAlg/Matrix.h"
+#include "Attitude/dcm_to_quaternion.h"
+#include "TestTools/QuaternionNear.h"
+
+#include <cmath>
+#include <gtest/gtest.h>
+#include <string>
+
+using MathUtils::Quaternion;
+using MathUtils::TestTools::QuaternionNear;
+using MathUtils::Matrix;
+
+namespace {
+
+const std::string test_reports_file = std::string("TESTRESULTS-dcm_to_quaternion_xml");
+
+// ====================================================================================================================
+TEST(DcmToQuaternionTest, SchaubTextbookExample)
+{
+  // Example 3.6 from "Analytical Mechanics of Aerospace Systems" (Schaub et. al.)
+  const double tolerance = 1e-5;
+
+  const Matrix<3,3> dcm {
+    0.892539, 0.157379, -0.422618,
+    -0.275451, 0.932257, -0.234570,
+    0.357073, 0.325773, 0.875426
+  };
+
+  const Quaternion expected {0.961798, -0.14565, 0.202665, 0.112505};
+
+  const Quaternion result = MathUtils::dcm_to_quaternion(dcm);
+
+  EXPECT_TRUE(QuaternionNear(result, expected, tolerance));
+}
+
+// ====================================================================================================================
+TEST(DcmToQuaternionTest, MathWorksExample1)
+{
+  // Example from https://www.mathworks.com/help/aerotbx/ug/dcm2quat.html
+  const double tolerance = 1e-4;
+
+  const Matrix<3,3> dcm {
+    0, 1, 0,
+    1, 0, 0,
+    0, 0, -1
+  };
+
+  const Quaternion expected {0, 0.7071, 0.7071, 0};
+
+  const Quaternion result = MathUtils::dcm_to_quaternion(dcm);
+
+  EXPECT_TRUE(QuaternionNear(result, expected, tolerance));
+}
+
+// ====================================================================================================================
+TEST(DcmToQuaternionTest, MathWorksExample2)
+{
+  // Example from https://www.mathworks.com/help/aerotbx/ug/dcm2quat.html
+  const double tolerance = 1e-4;
+
+  const Matrix<3,3> dcm {
+    0.4330, 0.2500, -0.8660,
+    0.1768, 0.9186, 0.3536,
+    0.8839, -0.3062, 0.3536
+  };
+
+  const Quaternion expected {0.8224, 0.2006, 0.5320, 0.0223};
+
+  const Quaternion result = MathUtils::dcm_to_quaternion(dcm);
+
+  EXPECT_TRUE(QuaternionNear(result, expected, tolerance));
+}
+
+// ====================================================================================================================
+TEST(DcmToQuaternionTest, MathWorksExample3)
+{
+  // Example from https://www.mathworks.com/help/aerotbx/ug/quat2dcm.html
+  const double tolerance = 1e-4;
+
+  const Matrix<3,3> dcm {
+    0, 0, -1,
+    0, 1, 0,
+    1, 0, 0
+  };
+
+  const Quaternion expected {1, 0, 1, 0};
+
+  const Quaternion result = MathUtils::dcm_to_quaternion(dcm);
+
+  EXPECT_TRUE(QuaternionNear(result, expected, tolerance));
+}
+
+// ====================================================================================================================
+TEST(DcmToQuaternionTest, MathWorksExample4)
+{
+  // Example from https://www.mathworks.com/help/aerotbx/ug/quat2dcm.html
+  const double tolerance = 1e-4;
+
+  const Matrix<3,3> dcm {
+    0.8519, 0.3704, -0.3704,
+    0.0741, 0.6148, 0.7852,
+    0.5185, -0.6963, 0.4963
+  };
+
+  const Quaternion expected {1, 0.5, 0.3, 0.1};
+
+  const Quaternion result = MathUtils::dcm_to_quaternion(dcm);
+
+  EXPECT_TRUE(QuaternionNear(result, expected, tolerance));
+}
+
+
+// ====================================================================================================================
+int main(int argc, char** argv)
+{
+  ::testing::GTEST_FLAG(output) = std::string("xml:") + test_reports_file;
+  ::testing::GTEST_FLAG(death_test_style) = "threadsafe";
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+}  // namespace


### PR DESCRIPTION
Created a function to convert a direction cosine matrix to a quaternion. Uses a method outlined in "Analytical Mechanics of Aerospace Systems" (Schaub et. al).

Also used some MathWorks examples to create unit tests.