### PR TITLE
33 Geodetic Coordinate Class | Pre-Compute Constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ Build/
 *.o
 *.so
 
-*.txt
 *.csv
 
 **/__pycache__/

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -4,14 +4,15 @@
         {
             "name": "Linux",
             "includePath": [
-                "${workspaceFolder}/**",
-                "${workspaceFolder}/include/**",
-                "${workspaceFolder}/include/LinAlg/**",
-                "${workspaceFolder}/include/Attitude/**",
-                "${workspaceFolder}/include/Internal/**",
-                "${workspaceFolder}/test/**",
-                "${workspaceFolder}/build/_deps/googletest-src/googletest/include/**",
-                "${workspaceFolder}/build/_deps/googletest-src/googlemock/include/**"
+                "${workspaceFolder}/",
+                "${workspaceFolder}/build/_deps/googletest-src/googlemock/include/",
+                "${workspaceFolder}/build/_deps/googletest-src/googletest/include/",
+                "${workspaceFolder}/include/",
+                "${workspaceFolder}/include/Attitude/",
+                "${workspaceFolder}/include/Geodesy/",
+                "${workspaceFolder}/include/Internal/",
+                "${workspaceFolder}/include/LinAlg/",
+                "${workspaceFolder}/test/"
             ],
             "cppStandard": "c++20",
             "intelliSenseMode": "linux-gcc-x64",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ set(INCL_DIR "include/")
 # folder names for sub-folders
 set(ATTITUDE_DIR "Attitude/")
 set(LINALG_DIR "LinAlg/")
+set(GEODESY_DIR "Geodesy/")
 
 
 # BUILD PROJECT =======================================================================================================
@@ -46,9 +47,14 @@ file(GLOB LINALG_SRC
     ${SRC_DIR}/${LINALG_DIR}/*.cpp
 )
 
+file(GLOB GEODESY_SRC
+    ${SRC_DIR}/${GEODESY_DIR}/*.cpp
+)
+
 # BUILD LIBRARY
 add_library(${MATHUTILS_LIB} SHARED
     ${ATTITUDE_SRC}
+    ${GEODESY_SRC}
     ${LINALG_SRC}
     ${SRC_DIR_SRC}
 )

--- a/include/Geodesy/GeoCoord.h
+++ b/include/Geodesy/GeoCoord.h
@@ -8,13 +8,14 @@
 #define MATHUTILS_GEODETIC_COORDS_H_
 
 #include <initializer_list>
+#include <utility>
 
 namespace MathUtils {
 
 /**
  * @brief Geodetic coordinate (latitude, longitude, altitude).
  *
- * @details Uses WGS84 geoid. Latitude is geodetic latitude [-90, 90] in [rad], longitude is [-180, 180] in [rad], and
+ * @details Uses WGS84 geoid. Latitude is [-90, 90] in [rad], longitude is [-180, 180] in [rad], and
  * altitude is MSL in [m].
  */
 class GeoCoord
@@ -24,12 +25,126 @@ public:
    * @brief Create a GeoCoord.
    */
   GeoCoord();
+
+  /**
+   * @brief Create a GeoCoord.
+   *
+   * @param latitude_rad Latitude in [rad].
+   * @param longitude_rad Longitude in [rad].
+   * @param altitude_m Altitude in [m].
+   */
+  GeoCoord(const double latitude_rad, const double longitude_rad, const double altitude_m);
+
+  /**
+   * @brief Create a GeoCoord.
+   *
+   * @param lla Latitude [rad], longitude [rad], altitude [m].
+   */
+  explicit GeoCoord(const std::initializer_list<double> lla);
+
+  /**
+   * @brief Copy construct GeoCoord.
+   *
+   * @param other Other GoeCoord.
+   */
+  GeoCoord(const GeoCoord& other);
+
+  /**
+   * @brief Move construct GeoCoord
+   *
+   * @param other Other GeoCoord.
+   */
+  GeoCoord(GeoCoord&& other) noexcept;
+
+  /**
+   * @brief Assing GeoCoord values from an initializer list.
+   *
+   * @param lla New latitude [rad]. longitude [rad], altitude [m].
+   * @return GeoCoord.
+   */
+  GeoCoord& operator=(const std::initializer_list<double> lla);
+
+  /**
+   * @brief Copy assign GeoCoord.
+   *
+   * @param other Other GeoCoord.
+   * @return GeoCoord.
+   */
+  GeoCoord& operator=(const GeoCoord& other);
+
+  /**
+   * @brief Move assign GeoCoord.
+   *
+   * @param other Other GeoCoord.
+   * @return GeoCoord.
+   */
+  GeoCoord& operator=(GeoCoord&& other) noexcept;
+
+  /**
+   * @brief Access latitude.
+   *
+   * @return Latitude [rad].
+   */
+  double& latitude() noexcept
+  {
+    return m_lat_rad;
+  }
+
+  /**
+   * @brief Get latitude.
+   *
+   * @return Latitude [rad].
+   */
+  const double& latitude() const noexcept
+  {
+    return m_lat_rad;
+  }
+
+  /**
+   * @brief Access longitude.
+   *
+   * @return Longitude [rad].
+   */
+  double& longitude() noexcept
+  {
+    return m_lon_rad;
+  }
+
+  /**
+   * @brief Get longitude.
+   *
+   * @return Longitude [rad].
+   */
+  const double& longitude() const noexcept
+  {
+    return m_lon_rad;
+  }
+
+  /**
+   * @brief Access altitude.
+   *
+   * @return Altitude [m].
+   */
+  double& altitude() noexcept
+  {
+    return m_alt_m;
+  }
+
+  /**
+   * @brief Access altitude.
+   *
+   * @return Altitude [m].
+   */
+  const double& altitude() const noexcept
+  {
+    return m_alt_m;
+  }
+
 protected:
 private:
-  double m_lat;  ///< Latitude in [rad], [-90, 90]
-  double m_lon;  ///< Longitude in [rad], [-180, 180].
-  double m_alt;  ///< Altitude in [m].
-
+  double m_lat_rad;  ///< Latitude in [rad], [-90, 90]
+  double m_lon_rad;  ///< Longitude in [rad], [-180, 180].
+  double m_alt_m;  ///< Altitude in [m].
 };
 
 }  // namespace MathUtils

--- a/include/Geodesy/GeoCoord.h
+++ b/include/Geodesy/GeoCoord.h
@@ -1,0 +1,37 @@
+/**
+ * @file GeoCoord.h
+ * @author Michael Wrona
+ * @date 2023-03-27
+ */
+
+#ifndef MATHUTILS_GEODETIC_COORDS_H_
+#define MATHUTILS_GEODETIC_COORDS_H_
+
+#include <initializer_list>
+
+namespace MathUtils {
+
+/**
+ * @brief Geodetic coordinate (latitude, longitude, altitude).
+ *
+ * @details Uses WGS84 geoid. Latitude is geodetic latitude [-90, 90] in [rad], longitude is [-180, 180] in [rad], and
+ * altitude is MSL in [m].
+ */
+class GeoCoord
+{
+public:
+  /**
+   * @brief Create a GeoCoord.
+   */
+  GeoCoord();
+protected:
+private:
+  double m_lat;  ///< Latitude in [rad], [-90, 90]
+  double m_lon;  ///< Longitude in [rad], [-180, 180].
+  double m_alt;  ///< Altitude in [m].
+
+};
+
+}  // namespace MathUtils
+
+#endif  // MATHUTILS_GEODETIC_COORDS_H_

--- a/include/constants.h
+++ b/include/constants.h
@@ -4,9 +4,12 @@
  * @date 2023-03-04
  * @brief Commonly used constants.
  *
+ * @details Computed with scripts/constants.py
+ *
  * @ref https://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf
  * @ref https://en.wikipedia.org/wiki/Earth_radius#Arithmetic_mean_radius
  * @ref https://en.wikipedia.org/w/index.php?title=International_Standard_Atmosphere
+ * @ref https://www.britannica.com/science/pi-mathematics
  */
 
 #ifndef MATHUTILS_CONSTANTS_H_
@@ -14,25 +17,21 @@
 
 namespace MathUtils { namespace Constants {
 
-static constexpr double PI = 3.141592653589793;  ///< Pi constant.
-static constexpr double TWO_PI = 2.0 * PI;  ///< Two time pi
-static constexpr double PI_DIV2 = 0.5 * PI;  ///< Pi divided by two, pi / 2
+constexpr double PI = 3.1415926535897931;  ///< Pi constant.
+constexpr double TWO_PI = 6.2831853071795862;  ///< Two time pi
+constexpr double PI_DIV2 = 1.5707963267948966;  ///< Pi divided by two, pi / 2
+constexpr double PI_DIV4 = 0.7853981633974483;  ///< Pi divided by four, pi / 4
 
-static constexpr double WGS84_RADIUS_M = 6371008.77141505945474;  ///< IUGG earth arithmetic mean radius, (2a + b) / 3 [m].
-static constexpr double WGS84_INVF = 298.257223563;  ///< WGS84 inverse of flattening.
-static constexpr double WGS84_F = 1.0 / WGS84_INVF;  ///< WGS84 flattening.
-static constexpr double WGS84_ECC2 = 0.00669437999014;  ///< WGS84 eccentricity squared e^2.
-static constexpr double WGS84_ECC = 0.08181919084262;  ///< WGS84 eccentricity.
-static constexpr double WGS84_A_M = 6378137.0;  ///< WGS84 semimajor axis [m].
-static constexpr double WGS84_B_M = 6356752.31424517929554;  ///< WGS semiminor axis [m].
-static constexpr double WGS84_GRAV_MPS2 = 9.80665;  ///< WGS84 standard gravity [m/s/s].
-static constexpr double WGS84_GM_M3PS2 = 3.986004418e14;  ///< WGS84 gravitational parameter [m^3 / s^2].
-static constexpr double WGS84_RATE_RPS = 7.292115e-5;  ///< WGS84 mean angular velocity [rad/sec].
-
-// International Civil Aviation Organization Standard Atmosphere
-static constexpr double ICAO_TEMP_C = 15.0;  ///< ICAO sea-level temperature [C].
-static constexpr double ICAO_PRES_PA = 101325.0;  ///< ICAO sea-level pressure [Pa].
-static constexpr double ICAO_LAPSE_RATE_CPM = -6.5e-3;  ///< ICAO sea-level temperature lapse rate [C/m]
+constexpr double WGS84_A_M = 6378137.0;  ///< WGS84 semimajor axis [m].
+constexpr double WGS84_INVF = 298.257223563;  ///< WGS84 inverse of flattening.
+constexpr double WGS84_F = 0.0033528106647475;  ///< WGS84 flattening.
+constexpr double WGS84_ECC2 = 0.0066943799901413;  ///< WGS84 eccentricity squared e^2.
+constexpr double WGS84_ECC = 0.0818191908426215;  ///< WGS84 eccentricity.
+constexpr double WGS84_B_M = 6356752.3142451792955399;  ///< WGS semiminor axis [m].
+constexpr double WGS84_RADIUS_M = 6371008.7714150594547391;  ///< IUGG earth arithmetic mean radius, (2a + b) / 3 [m].
+constexpr double WGS84_GRAV_MPS2 = 9.80665;  ///< WGS84 standard gravity [m/s/s].
+constexpr double WGS84_GM_M3PS2 = 3.986004418e14;  ///< WGS84 gravitational parameter [m^3 / s^2].
+constexpr double WGS84_RATE_RPS = 7.292115e-5;  ///< WGS84 mean angular velocity [rad/sec].
 
 }  // namespace Constants
 }  // namespace MathUtils

--- a/scripts/constants.py
+++ b/scripts/constants.py
@@ -1,0 +1,37 @@
+"""
+Print constants.
+
+These print the constants values used in constants.h.
+
+Code By: Michael Wrona
+Created: 27 march 2023
+
+"""
+import math as m
+
+# pi from https://www.britannica.com/science/pi-mathematics
+pi = 3.141592653589793238462643383279502884197
+
+print(f"pi = {pi:0.16f}")
+print(f"2pi = {2.0*pi:0.16f}")
+print(f"pi/2 = {0.5*pi:0.16f}")
+print(f"pi/4 = {0.25*pi:0.16f}")
+
+# WGS84 constants from https://www.unoosa.org/pdf/icg/2012/template/WGS_84.pdf
+a = 6378137.0  # [m]
+inv_f = 298.257223563
+
+f = 1.0 / inv_f
+print(f"f = {f:0.16f}")
+
+ecc2 = 2 * f - f**2
+print(f"ecc2 = {ecc2:0.16f}")
+
+ecc = m.sqrt(ecc2)
+print(f"ecc = {ecc:0.16f}")
+
+b = a * (1 - f)
+print(f"b = {b:0.16f}")  # [m]
+
+radius = (2 * a + b) / 3
+print(f"radius = {radius:0.16f}")  # [m]

--- a/src/Geodesy/GeoCoord.cpp
+++ b/src/Geodesy/GeoCoord.cpp
@@ -1,0 +1,21 @@
+/**
+ * @file GeoCoord.cpp
+ * @author Michael Wrona
+ * @date 2023-03-27
+ */
+
+#include "Geodesy/GeoCoord.h"
+
+#include <cassert>
+#include <cstddef>
+
+namespace MathUtils {
+
+GeoCoord::GeoCoord()
+  :m_lat{},
+  m_lon{},
+  m_alt{}
+{}
+
+
+}  // namespace MathUtils

--- a/src/Geodesy/GeoCoord.cpp
+++ b/src/Geodesy/GeoCoord.cpp
@@ -4,18 +4,126 @@
  * @date 2023-03-27
  */
 
+#include "constants.h"
 #include "Geodesy/GeoCoord.h"
+#include "Internal/error_msg_helpers.h"
 
 #include <cassert>
+#include <cmath>
 #include <cstddef>
+#include <stdexcept>
 
 namespace MathUtils {
 
+
 GeoCoord::GeoCoord()
-  :m_lat{},
-  m_lon{},
-  m_alt{}
+  :m_lat_rad{},
+  m_lon_rad{},
+  m_alt_m{}
 {}
 
+
+GeoCoord::GeoCoord(const double latitude_rad, const double longitude_rad, const double altitude_m)
+  :m_lat_rad{latitude_rad},
+  m_lon_rad{longitude_rad},
+  m_alt_m{altitude_m}
+{
+  assert(std::abs(m_lat_rad) <= Constants::PI_DIV2);  // within [-90, 90] deg
+  assert(std::abs(m_lon_rad) <= Constants::PI);  // within [-180, 180] deg
+}
+
+
+GeoCoord::GeoCoord(const std::initializer_list<double> lla)
+{
+  const std::size_t input_size = lla.size();
+
+  if (input_size != 3)
+  {
+    throw std::length_error(Internal::invalid_init_list_length_error_msg(input_size, 3));
+  }
+
+  auto vals = lla.begin();
+
+  m_lat_rad = *(vals++);
+  assert(vals != lla.end());
+
+  m_lon_rad = *(vals++);
+  assert(vals != lla.end());
+
+  m_alt_m = *(vals++);
+  assert(vals == lla.end());
+
+  assert(std::abs(m_lat_rad) <= Constants::PI_DIV2);  // within [-90, 90] deg
+  assert(std::abs(m_lon_rad) <= Constants::PI);  // within [-180, 180] deg
+}
+
+
+GeoCoord::GeoCoord(const GeoCoord& other)
+  :m_lat_rad{other.m_lat_rad},
+  m_lon_rad{other.m_lon_rad},
+  m_alt_m{other.m_alt_m}
+{}
+
+
+GeoCoord::GeoCoord(GeoCoord&& other) noexcept
+  :m_lat_rad{std::exchange(other.m_lat_rad, 0.0)},
+  m_lon_rad{std::exchange(other.m_lon_rad, 0.0)},
+  m_alt_m{std::exchange(other.m_alt_m, 0.0)}
+{}
+
+
+GeoCoord& GeoCoord::operator=(const std::initializer_list<double> lla)
+{
+  const std::size_t input_size = lla.size();
+
+  if (input_size != 3)
+  {
+    throw std::length_error(Internal::invalid_init_list_length_error_msg(input_size, 3));
+  }
+
+  auto vals = lla.begin();
+
+  m_lat_rad = *(vals++);
+  assert(vals != lla.end());
+
+  m_lon_rad = *(vals++);
+  assert(vals != lla.end());
+
+  m_alt_m = *(vals++);
+  assert(vals == lla.end());
+
+  assert(std::abs(m_lat_rad) <= Constants::PI_DIV2);  // within [-90, 90] deg
+  assert(std::abs(m_lon_rad) <= Constants::PI);  // within [-180, 180] deg
+
+  return *this;
+}
+
+
+GeoCoord& GeoCoord::operator=(const GeoCoord& other)
+{
+  if (&other == this)
+  {
+    return *this;
+  }
+
+  m_lat_rad = other.m_lat_rad;
+  m_lon_rad = other.m_lon_rad;
+  m_alt_m = other.m_alt_m;
+  return *this;
+}
+
+
+GeoCoord& GeoCoord::operator=(GeoCoord&& other) noexcept
+{
+  if (&other == this)
+  {
+    return *this;
+  }
+
+  m_lat_rad = std::exchange(other.m_lat_rad, 0.0);
+  m_lon_rad = std::exchange(other.m_lon_rad, 0.0);
+  m_alt_m = std::exchange(other.m_alt_m, 0.0);
+  return *this;
+}
 
 }  // namespace MathUtils

--- a/test/Attitude/test_dcm_to_quaternion.cpp
+++ b/test/Attitude/test_dcm_to_quaternion.cpp
@@ -19,7 +19,7 @@ using MathUtils::Matrix;
 
 namespace {
 
-const std::string test_reports_file = std::string("TESTRESULTS-dcm_to_quaternion_xml");
+const std::string test_reports_file = std::string("TESTRESULTS-dcm_to_quaternion.xml");
 
 // ====================================================================================================================
 TEST(DcmToQuaternionTest, SchaubTextbookExample)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,5 +48,6 @@ add_test(NAME ${TEST_MATHUTILS_EXEC}
 )
 
 # MAKE OTHER TESTS ====================================================================================================
-add_subdirectory("./LinAlg/")
 add_subdirectory("./Attitude/")
+add_subdirectory("./Geodesy/")
+add_subdirectory("./LinAlg/")

--- a/test/Geodesy/CMakeLists.txt
+++ b/test/Geodesy/CMakeLists.txt
@@ -1,0 +1,28 @@
+# BUILD TESTS =========================================================================================================
+set(TEST_GEODESY_EXEC test_geodesy)
+
+# get sources
+file(GLOB TEST_LINALG_SRC
+  ./*.cpp
+  ${MATHUTILS_TEST_DIR}/TestTools/*.cpp
+)
+
+add_executable(${TEST_GEODESY_EXEC}
+  ${TEST_LINALG_SRC}
+)
+
+target_include_directories(${TEST_GEODESY_EXEC} PUBLIC
+  ${CMAKE_SOURCE_DIR}/${INCL_DIR}
+  ${MATHUTILS_TEST_DIR}
+)
+
+target_link_libraries(${TEST_GEODESY_EXEC} PUBLIC
+  "$<$<CONFIG:DEBUG>:--coverage>"
+  ${MATHUTILS_LIB}
+  GTest::gtest_main
+)
+
+# ADD TESTS ===========================================================================================================
+add_test(NAME ${TEST_GEODESY_EXEC}
+  COMMAND ${TEST_GEODESY_EXEC}
+)

--- a/test/Geodesy/test_GeoCoord.cpp
+++ b/test/Geodesy/test_GeoCoord.cpp
@@ -5,15 +5,152 @@
  */
 
 #include "Geodesy/GeoCoord.h"
+#include "TestTools/GeoCoordNear.h"
 
 #include <gtest/gtest.h>
 #include <string>
 
+using MathUtils::GeoCoord;
+using MathUtils::TestTools::GeoCoordNear;
 
 namespace {
 
-const std::string test_reports_file = std::string("TESTRESULTS-geokcoord.xml");
+const std::string test_reports_file = std::string("TESTRESULTS-geocoord.xml");
 
+class GeoCoordTest : public ::testing::Test
+{
+public:
+  GeoCoordTest()
+    :c1{-0.1, 0.2, 34.0},
+    c1_lat{-0.1},
+    c1_lon{0.2},
+    c1_alt{34.0},
+    c2{0.2, 0.3, 56.0}
+  {}
+protected:
+  void SetUp() override {}
+  void TearDown() override {}
+
+  const GeoCoord c1;
+  const double c1_lat;
+  const double c1_lon;
+  const double c1_alt;
+  const GeoCoord c2;
+private:
+};
+
+// ====================================================================================================================
+TEST_F(GeoCoordTest, DefaultConstruct)
+{
+  GeoCoord gc;
+
+  EXPECT_DOUBLE_EQ(gc.latitude(), 0.0);
+  EXPECT_DOUBLE_EQ(gc.longitude(), 0.0);
+  EXPECT_DOUBLE_EQ(gc.altitude(), 0.0);
+}
+
+// ====================================================================================================================
+TEST_F(GeoCoordTest, ThreeArgConstruct)
+{
+  GeoCoord gc(0.1, 0.2, 56);
+
+  EXPECT_DOUBLE_EQ(gc.latitude(), 0.1);
+  EXPECT_DOUBLE_EQ(gc.longitude(), 0.2);
+  EXPECT_DOUBLE_EQ(gc.altitude(), 56);
+}
+
+// ====================================================================================================================
+TEST(GeoCoordDeathTest, ThreeArgConstructAssertsInvalidLatitude)
+{
+  EXPECT_DEBUG_DEATH({
+    GeoCoord gc(-12, 0.3, 123);
+  }, "");
+}
+
+// ====================================================================================================================
+TEST(GeoCoordDeathTest, ThreeArgConstructAssertsInvalidLongitude)
+{
+  EXPECT_DEBUG_DEATH({
+    GeoCoord gc(0.3, 12, 123);
+  }, "");
+}
+
+// ====================================================================================================================
+TEST_F(GeoCoordTest, ListInitConstructor)
+{
+  GeoCoord gc ({-0.2, -0.4, 68.0});
+}
+
+// ====================================================================================================================
+TEST_F(GeoCoordTest, ListInitConstructorThrowsInvalidSize)
+{
+  EXPECT_THROW({
+    GeoCoord gc ({-0.2, -0.4, 68.0, 123.0});
+  }, std::length_error);
+}
+
+// ====================================================================================================================
+TEST_F(GeoCoordTest, CopyConstruct)
+{
+  GeoCoord gc_copy(c1);
+
+  EXPECT_TRUE(GeoCoordNear(gc_copy, c1));
+}
+
+// ====================================================================================================================
+TEST_F(GeoCoordTest, MoveConstruct)
+{
+  GeoCoord gc(0.1, 0.2, 345.0);
+
+  GeoCoord gc_new(std::move(gc));
+
+  EXPECT_DOUBLE_EQ(gc_new.latitude(), 0.1);
+  EXPECT_DOUBLE_EQ(gc_new.longitude(), 0.2);
+  EXPECT_DOUBLE_EQ(gc_new.altitude(), 345.0);
+}
+
+// ====================================================================================================================
+TEST_F(GeoCoordTest, ListInitAssign)
+{
+  GeoCoord gc;
+  gc = {-0.2, -0.4, 68.0};
+
+  EXPECT_DOUBLE_EQ(gc.latitude(), -0.2);
+  EXPECT_DOUBLE_EQ(gc.longitude(), -0.4);
+  EXPECT_DOUBLE_EQ(gc.altitude(), 68.0);
+}
+
+// ====================================================================================================================
+TEST_F(GeoCoordTest, ListInitAssignThrowsInvalidSize)
+{
+  GeoCoord gc;
+  std::initializer_list<double> vals = {-0.5, 0.5};
+  EXPECT_THROW({
+    gc = vals;
+  }, std::length_error);
+}
+
+// ====================================================================================================================
+TEST_F(GeoCoordTest, CopyAssign)
+{
+  GeoCoord gc_copy;
+  gc_copy = c1;
+
+  EXPECT_TRUE(GeoCoordNear(gc_copy, c1));
+}
+
+// ====================================================================================================================
+TEST_F(GeoCoordTest, MoveAssign)
+{
+  GeoCoord gc(0.1, 0.2, 345.0);
+
+  GeoCoord gc_new;
+  gc_new = std::move(gc);
+
+  EXPECT_DOUBLE_EQ(gc_new.latitude(), 0.1);
+  EXPECT_DOUBLE_EQ(gc_new.longitude(), 0.2);
+  EXPECT_DOUBLE_EQ(gc_new.altitude(), 345.0);
+}
 
 // ====================================================================================================================
 int main(int argc, char** argv)

--- a/test/Geodesy/test_GeoCoord.cpp
+++ b/test/Geodesy/test_GeoCoord.cpp
@@ -1,0 +1,28 @@
+/**
+ * @file test_GeoCoord.cpp
+ * @author Michael Wrona
+ * @date 2023-03-27
+ */
+
+#include "Geodesy/GeoCoord.h"
+
+#include <gtest/gtest.h>
+#include <string>
+
+
+namespace {
+
+const std::string test_reports_file = std::string("TESTRESULTS-geokcoord.xml");
+
+
+// ====================================================================================================================
+int main(int argc, char** argv)
+{
+  ::testing::GTEST_FLAG(output) = std::string("xml:") + test_reports_file;
+  ::testing::GTEST_FLAG(death_test_style) = "threadsafe";
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+}  // namespace

--- a/test/TestTools/GeoCoordNear.cpp
+++ b/test/TestTools/GeoCoordNear.cpp
@@ -1,0 +1,55 @@
+/**
+ * @file GeoCoordNear.cpp
+ * @author Michael Wrona
+ * @date 2023-03-28
+ */
+
+#include "TestTools/GeoCoordNear.h"
+
+#include <cmath>
+#include <iomanip>
+#include <sstream>
+
+namespace MathUtils {
+namespace TestTools {
+
+::testing::AssertionResult GeoCoordNear(const MathUtils::GeoCoord& c1,
+  const MathUtils::GeoCoord& c2, const double tol)
+{
+  bool success = true;
+  std::stringstream error_msgs;
+
+  // compute diffs
+  const double lat_diff = std::abs(c1.latitude() - c2.latitude());
+  const double lon_diff = std::abs(c1.longitude() - c2.longitude());
+  const double alt_diff = std::abs(c1.altitude() - c2.altitude());
+
+  // check tolerance
+  if (lat_diff > tol)
+  {
+    success = false;
+    error_msgs << "\nLatitude differs by " << std::scientific << lat_diff;
+  }
+
+  if (lon_diff > tol)
+  {
+    success = false;
+    error_msgs << "\nLongitude differs by " << std::scientific << lon_diff;
+  }
+
+  if (alt_diff > tol)
+  {
+    success = false;
+    error_msgs << "\nAltitude differs by " << std::scientific << alt_diff;
+  }
+
+  if (!success)
+  {
+    return ::testing::AssertionFailure() << "GeoCoords are not equal." << error_msgs.str();
+  }
+
+  return ::testing::AssertionSuccess();
+}
+
+}  // namespace TestTools
+}  // namespace MathUtils

--- a/test/TestTools/GeoCoordNear.h
+++ b/test/TestTools/GeoCoordNear.h
@@ -1,0 +1,34 @@
+/**
+ * @file GeoCoordNear.h
+ * @author Michael Wrona
+ * @date 2023-03-28
+ */
+
+#ifndef MATHUTILS_GTEST_TOOLS_GEOCOORD_NEAR_H_
+#define MATHUTILS_GTEST_TOOLS_GEOCOORD_NEAR_H_
+
+#include "Geodesy/GeoCoord.h"
+
+#include <cmath>
+#include <gtest/gtest.h>
+#include <iomanip>
+#include <sstream>
+
+namespace MathUtils {
+namespace TestTools {
+
+/**
+ * @brief Check two MathUtils::GeoCoord for equality.
+ *
+ * @param mat1 First coord.
+ * @param mat2 Second coord.
+ * @param tol Absolute tolerance for each element. Defaults to 1e-14.
+ * @returns Test assertion success or failure.
+ */
+::testing::AssertionResult GeoCoordNear(const MathUtils::GeoCoord& c1,
+  const MathUtils::GeoCoord& c2, const double tol=1e-14);
+
+}  // namespace TestTools
+}  // namespace MathUtils
+
+#endif  // MATHUTILS_GTEST_TOOLS_GEOCOORD_NEAR_H_


### PR DESCRIPTION
## GeoCoord

Created a simple `GeoCoord` class for storing geodetic latitude, longitude, and altitude coordinates. The main motivator for creating this was to not store LLA in a `MathUtils::Vector`.

## Constants

Created a Python script to pre-compute constants with fixed-precision.