### PR TITLE
Use ruff with pre-commit

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,7 @@
     "customizations": {
         "vscode": {
             "extensions": [
+                "charliermarsh.ruff",
                 "cschlosser.doxdocgen",
                 "davidanson.vscode-markdownlint",
                 "eamodio.gitlens",

--- a/.devcontainer/requirements.txt
+++ b/.devcontainer/requirements.txt
@@ -3,5 +3,6 @@ cppcheck-junit
 isort
 numpy
 pre-commit
+pre-commit-update
 scipy
 sympy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,17 +1,23 @@
 exclude: "cmake"
 
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
-    hooks:
-    -   id: check-json
-    -   id: check-toml
-    -   id: check-yaml
-    -   id: check-case-conflict
-    -   id: check-merge-conflict
-    -   id: trailing-whitespace
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v4.4.0
+      hooks:
+          - id: check-json
+          - id: check-toml
+          - id: check-yaml
+          - id: check-case-conflict
+          - id: check-merge-conflict
+          - id: trailing-whitespace
 
--   repo: https://github.com/psf/black
-    rev: 23.1.0
-    hooks:
-    -   id: black
+    - repo: https://github.com/psf/black
+      rev: 23.1.0
+      hooks:
+          - id: black
+
+    - repo: https://github.com/charliermarsh/ruff-pre-commit
+      rev: "v0.0.257"
+      hooks:
+          - id: ruff
+            args: [--fix]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0.0",
-"tasks": [
+  "tasks": [
     {
       "label": "Build (Debug)",
       "type": "shell",
@@ -18,7 +18,7 @@
       "label": "Build (Release)",
       "type": "shell",
       "group": {
-          "kind": "build"
+        "kind": "build"
       },
       "linux": {
         "command": "cmake -B build/ -DCMAKE_BUILD_TYPE=Release && cmake --build build/ -j"
@@ -31,7 +31,9 @@
       "label": "Run Tests",
       "type": "shell",
       "group": "test",
-      "dependsOn": ["Build (Debug)"],
+      "dependsOn": [
+        "Build (Debug)"
+      ],
       "presentation": {
         "reveal": "always",
         "panel": "shared"
@@ -47,10 +49,24 @@
       "label": "Static Analysis",
       "type": "shell",
       "group": {
-          "kind": "none"
+        "kind": "none"
       },
       "linux": {
         "command": "./scripts/run-cppcheck.sh"
+      },
+      "options": {
+        "cwd": "${workspaceFolder}"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Run pre-commit",
+      "type": "shell",
+      "group": {
+        "kind": "none"
+      },
+      "linux": {
+        "command": "pre-commit run --all-files"
       },
       "options": {
         "cwd": "${workspaceFolder}"


### PR DESCRIPTION
Address #39. Use [ruff](https://github.com/charliermarsh/ruff) instead of isort, which has the same functionality, and more while being faster.

Also include [pre-commit-update](https://gitlab.com/vojko.pribudic/pre-commit-update) for helping to update hooks