### PR TITLE
Added .at() Accessor to Matrix, Vector, and Quaternion

### DIFF
--- a/include/Attitude/Quaternion.h
+++ b/include/Attitude/Quaternion.h
@@ -11,7 +11,6 @@
 #include "LinAlg/Vector.h"
 
 #include <array>
-#include <functional>
 #include <initializer_list>
 #include <iostream>
 
@@ -104,6 +103,16 @@ public:
      * @return Quaternion element at specified index.
      */
     const double& operator()(const std::size_t idx) const noexcept;
+
+    /**
+     * @brief Get quaternion element. With bounds checking.
+     *
+     * @param idx Quaternion index.
+     * @return Value at index.
+     *
+     * @exception std::out_of_range Invalid quaternion index.
+     */
+    const double& at(const std::size_t idx) const;
 
     /**
      * @brief Return the inverse of the quaternion.

--- a/include/LinAlg/Matrix.h
+++ b/include/LinAlg/Matrix.h
@@ -186,7 +186,7 @@ public:
     }
 
     /**
-     * @brief Access matrix element.
+     * @brief Access matrix element. No bounds checking.
      *
      * @param row Row index.
      * @param col Column index.
@@ -201,7 +201,7 @@ public:
     }
 
     /**
-     * @brief Get matrix element.
+     * @brief Get matrix element. No bounds checking.
      *
      * @param row Row index.
      * @param col Column index.
@@ -211,6 +211,42 @@ public:
     {
         assert(row < T_ROWS);
         assert(col < T_COLS);
+        return m_arr[(row * T_COLS) + col];
+    }
+
+    /**
+     * @brief Access matrix element. With bounds checking.
+     *
+     * @param row Row index.
+     * @param col Column index.
+     * @return Matrix element at specified index.
+     *
+     * @exception std::out_of_range Invalid matrix index.
+     */
+    double& at(const std::size_t row, std::size_t col)
+    {
+        if (row >= T_ROWS || col >= T_COLS) {
+            throw std::out_of_range(Internal::invalid_index_error_msg(row, col, T_ROWS, T_COLS));
+        }
+
+        return m_arr[(row * T_COLS) + col];
+    }
+
+    /**
+     * @brief Get matrix element.  With bounds checking.
+     *
+     * @param row Row index.
+     * @param col Column index.
+     * @return Matrix element at specified index.
+     *
+     * @exception std::out_of_range Invalid matrix index.
+     */
+    const double& at(const std::size_t row, std::size_t col) const
+    {
+        if (row >= T_ROWS || col >= T_COLS) {
+            throw std::out_of_range(Internal::invalid_index_error_msg(row, col, T_ROWS, T_COLS));
+        }
+
         return m_arr[(row * T_COLS) + col];
     }
 

--- a/include/LinAlg/Vector.h
+++ b/include/LinAlg/Vector.h
@@ -149,7 +149,7 @@ public:
     }
 
     /**
-     * @brief Access vector element.
+     * @brief Access vector element. No bounds checks.
      *
      * @param idx Vector index.
      * @return Vector element at specified index.
@@ -161,7 +161,7 @@ public:
     }
 
     /**
-     * @brief Get vector element.
+     * @brief Get vector element. No bounds checks.
      *
      * @param idx Vector index.
      * @return Vector value at specified index.
@@ -169,6 +169,40 @@ public:
     const double& operator()(const std::size_t idx) const noexcept
     {
         assert(idx < T_LEN);
+        return m_arr[idx];
+    }
+
+    /**
+     * @brief Access vector element. With bounds checks.
+     *
+     * @param idx Vector index.
+     * @return Vector element at specified index.
+     *
+     * @exception std::out_of_range Invalid vector index.
+     */
+    double& at(const std::size_t idx)
+    {
+        if (idx >= T_LEN) {
+            throw std::out_of_range(Internal::invalid_index_error_msg(idx, T_LEN));
+        }
+
+        return m_arr[idx];
+    }
+
+    /**
+     * @brief Get vector element. With bounds checks.
+     *
+     * @param idx Vector index.
+     * @return Vector element at specified index.
+     *
+     * @exception std::out_of_range Invalid vector index.
+     */
+    const double& at(const std::size_t idx) const
+    {
+        if (idx >= T_LEN) {
+            throw std::out_of_range(Internal::invalid_index_error_msg(idx, T_LEN));
+        }
+
         return m_arr[idx];
     }
 

--- a/src/Attitude/Quaternion.cpp
+++ b/src/Attitude/Quaternion.cpp
@@ -7,15 +7,16 @@
 #include "Attitude/Quaternion.h"
 
 #include "acos_safe.h"
-#include "constants.h"
 #include "float_equality.h"
 #include "Internal/error_msg_helpers.h"
 
 #include <algorithm>
 #include <cassert>
 #include <cmath>
+#include <functional>
 #include <initializer_list>
 #include <iomanip>
+#include <stdexcept>
 #include <type_traits>
 
 namespace MathUtils {
@@ -93,6 +94,16 @@ Quaternion& Quaternion::operator=(const std::initializer_list<double> quat_vals)
 const double& Quaternion::operator()(const std::size_t idx) const noexcept
 {
     assert(idx < 4);
+    return m_arr[idx];
+}
+
+
+const double& Quaternion::at(const std::size_t idx) const
+{
+    if (idx >= 4) {
+        throw std::out_of_range(Internal::invalid_index_error_msg(idx, 4));
+    }
+
     return m_arr[idx];
 }
 

--- a/test/Attitude/Quaternion_test.cpp
+++ b/test/Attitude/Quaternion_test.cpp
@@ -145,15 +145,6 @@ TEST(QuaternionTest, InitializerListAssign)
 }
 
 // =================================================================================================
-TEST(QuaternionDeathTest, InvalidIndexAsserts)
-{
-    EXPECT_DEBUG_DEATH({
-        Quaternion quat;
-        quat(4);
-    }, "");
-}
-
-// =================================================================================================
 TEST(QuaternionTest, InvalidLengthAssignmentThrows)
 {
     std::initializer_list<double> vals = {1, 2, 3};
@@ -162,6 +153,16 @@ TEST(QuaternionTest, InvalidLengthAssignmentThrows)
         Quaternion quat;
         quat = vals;
     }, std::length_error);
+}
+
+// =================================================================================================
+TEST(QuaternionTest, InvalidIndexThrows)
+{
+    Quaternion quat({1, 2, 3, 4});
+
+    EXPECT_THROW({
+        quat.at(4);
+    }, std::out_of_range);
 }
 
 // =================================================================================================

--- a/test/LinAlg/Matrix_test.cpp
+++ b/test/LinAlg/Matrix_test.cpp
@@ -116,43 +116,23 @@ TEST(MatrixTest, MoveConstruct)
 }
 
 // =================================================================================================
-TEST(MatrixDeathTest, GetInvalidRowIndexAsserts)
+TEST(MatrixTest, InvalidAtAccessorIndexThrows)
 {
-    Matrix<2,2> mat;
+    Matrix<2,2> mat {{1, 2}, {3, 4}};
 
-    EXPECT_DEBUG_DEATH({
-        mat(3, 0);
-    }, "");
+    EXPECT_THROW({
+        double a = mat.at(2, 0);
+    }, std::out_of_range);
 }
 
 // =================================================================================================
-TEST(MatrixDeathTest, GetInvalidColumnIndexAsserts)
+TEST(MatrixTest, InvalidAtModifierIndexThrows)
 {
-    Matrix<2,2> mat;
+    Matrix<2,2> mat {{1, 2}, {3, 4}};
 
-    EXPECT_DEBUG_DEATH({
-        mat(0, 4);
-    }, "");
-}
-
-// =================================================================================================
-TEST(MatrixDeathTest, ModifyInvalidRowIndexAsserts)
-{
-    Matrix<2,2> mat;
-
-    EXPECT_DEBUG_DEATH({
-        mat(3, 0) = 123;
-    }, "");
-}
-
-// =================================================================================================
-TEST(MatrixDeathTest, ModifyInvalidColumnIndexAsserts)
-{
-    Matrix<2,2> mat;
-
-    EXPECT_DEBUG_DEATH({
-        mat(0, 4) = 456;
-    }, "");
+    EXPECT_THROW({
+        mat.at(2, 0) = 456.0;
+    }, std::out_of_range);
 }
 
 // =================================================================================================

--- a/test/LinAlg/Vector_test.cpp
+++ b/test/LinAlg/Vector_test.cpp
@@ -138,13 +138,23 @@ TEST(VectorTest, ParenthesisAccessorModifiesValues)
 }
 
 // =================================================================================================
-TEST(VectorDeathTest, ParenthesisAccessorAssertsInvalidIndex)
+TEST(VectorTest, InvalidAtAccessorIndexThrows)
 {
     Vector<3> vec {1, 2, 3};
 
-    EXPECT_DEBUG_DEATH({
-        vec(4);
-    }, "");
+    EXPECT_THROW({
+        double b = vec.at(3);
+    }, std::out_of_range);
+}
+
+// =================================================================================================
+TEST(VectorTest, InvalidAtModifierIndexThrows)
+{
+    Vector<3> vec {1, 2, 3};
+
+    EXPECT_THROW({
+        vec.at(3) = 34.0;
+    }, std::out_of_range);
 }
 
 // =================================================================================================


### PR DESCRIPTION
Added `.at()` accessor to access elements and perform bounds checking. Throws `std::out_of_range` like `std::array` does.

I learned you cannot have two arguments for overloading `operator[]`.

Removed death tests that tested the `()` accessors for `assert`.