### PR TITLE
ECEF to LLA utility

### DIFF
--- a/include/Geodesy/ecef_to_lla.h
+++ b/include/Geodesy/ecef_to_lla.h
@@ -1,0 +1,30 @@
+/**
+ * @file ecef_to_lla.h
+ * @author Michael Wrona
+ * @date 2023-04-04
+ */
+
+#ifndef MATHUTILS_ECEF_TO_LLA_H_
+#define MATHUTILS_ECEF_TO_LLA_H_
+
+#include "Geodesy/GeoCoord.h"
+#include "LinAlg/Vector.h"
+
+namespace MathUtils {
+
+/**
+ * @brief Convert earth-centered, earth-fixed position to geodetic latitude, longitude, and
+ * altitude.
+ *
+ * @details Method from https://danceswithcode.net/engineeringnotes/geodetic_to_ecef/geodetic_to_ecef.html
+ *
+ * @param pos_ecef_m ECEF position in [m].
+ * @return Geodetic LLA in [rad] and [m].
+ *
+ * @see MathUtils::Constants
+ */
+GeoCoord ecef_to_lla(const Vector<3>& pos_ecef_m);
+
+}  // namespace MathUtils
+
+#endif  // MATHUTILS_ECEF_TO_LLA_H_

--- a/src/Geodesy/ecef_to_lla.cpp
+++ b/src/Geodesy/ecef_to_lla.cpp
@@ -1,0 +1,86 @@
+/**
+ * @file ecef_to_lla.cpp
+ * @author Michael Wrona
+ * @date 2023-04-04
+ */
+
+#include "Geodesy/ecef_to_lla.h"
+
+#include "constants.h"
+
+#include <cassert>
+#include <cmath>
+
+namespace MathUtils {
+
+GeoCoord ecef_to_lla(const Vector<3>& pos_ecef_m)
+{
+    // pre-computed variables
+    constexpr double a1 = Constants::WGS84_A_M * Constants::WGS84_ECC2;
+    constexpr double a2 = a1 * a1;
+    constexpr double a3 = 0.5 * a1 * Constants::WGS84_ECC2;
+    constexpr double a4 = 2.5 * a2;
+    constexpr double a5 = a1 + a3;
+    constexpr double a6 = 1.0 - Constants::WGS84_ECC2;
+
+    const double x = pos_ecef_m(0);
+    const double y = pos_ecef_m(1);
+    const double z = pos_ecef_m(2);
+
+    const double longitude_rad = std::atan2(y, x);  // final longitude [rad]
+
+    const double zp = std::abs(z);
+
+    const double w2 = x*x + y*y;
+    const double w = std::sqrt(w2);
+
+    const double r2 = w2 + z*z;
+    const double r = std::sqrt(r2);
+
+    const double s2 = z*z/r2;
+    const double c2 = w2/r2;
+
+    double u = a2/r;
+    double v = a3 - a4/r;
+
+    double s{};
+    double ss{};
+    double c{};
+    double latitude_rad{};
+
+    // TODO: Use safe trig?
+    if (c2 > 0.3) {
+        s = (zp/r) * (1.0 + c2*(a1 + u + s2*v)/r);
+        latitude_rad = std::asin(s);
+        ss = s * s;
+        c = std::sqrt(1.0 - ss);
+    }
+    else {
+        c = (w/r) * (1.0 - s2*(a5 - u - c2*v)/r);
+        latitude_rad = std::acos(c);
+        ss = 1.0 - c*c;
+        s = std::sqrt(ss);
+    }
+
+    const double g = 1.0 - Constants::WGS84_ECC2*ss;
+    const double rg = Constants::WGS84_A_M / std::sqrt(g);
+    const double rf = a6 * rg;
+
+    u = w - rg*c;
+    v = zp - rf*s;
+
+    const double f = c*u + s*v;
+    const double m = c*v - s*u;
+    const double p = m / (rf/g + f);
+
+    latitude_rad += p;
+    const double altitude_m = f + m*p*0.5;  // final altitude [m]
+
+    if (z < 0.0) {
+        latitude_rad *= -1.0;  // final latitude
+    }
+
+    return GeoCoord(latitude_rad, longitude_rad, altitude_m);
+}
+
+}  // namespace MathUtils

--- a/test/Geodesy/ecef_to_lla_test.cpp
+++ b/test/Geodesy/ecef_to_lla_test.cpp
@@ -1,0 +1,86 @@
+/**
+ * @file ecef_to_lla_test.cpp
+ * @author Michael Wrona
+ * @date 2023-04-04
+ */
+
+#include "conversions.h"
+#include "Geodesy/ecef_to_lla.h"
+#include "Geodesy/GeoCoord.h"
+#include "LinAlg/Vector.h"
+#include "TestTools/GeoCoordNear.h"
+
+#include <gtest/gtest.h>
+
+using MathUtils::Conversions::deg2rad;
+using MathUtils::ecef_to_lla;
+using MathUtils::GeoCoord;
+using MathUtils::TestTools::GeoCoordNear;
+using MathUtils::Vector;
+
+namespace {
+
+const std::string test_reports_file = std::string("TESTRESULTS-ecef_to_lla.xml");
+
+// =================================================================================================
+TEST(EcefToLlaTest, CompareAgainstOrigAlgorithm)
+{
+    // https://onlinegdb.com/75nsiXgfz
+    const Vector<3> pos_m {6'378'137.0+10e3, -6'378'137.0-11e3, 6'378'137.0+12e3};
+
+    const GeoCoord expected(
+        0.6174137445601836,
+        -0.7854764273524952,
+        4695313.846401864
+    );
+
+    const GeoCoord result = ecef_to_lla(pos_m);
+
+    EXPECT_TRUE(GeoCoordNear(result, expected, 5e-9));
+}
+
+// =================================================================================================
+TEST(EcefToLlaTest, MathWorksExample1)
+{
+    // https://www.mathworks.com/help/aerotbx/ug/ecef2lla.html
+    const Vector<3> pos_m {4510731.0, 4510731.0, 0.0};
+
+    const GeoCoord expected(
+        0.0,
+        deg2rad(45.0),
+        999.9564
+    );
+
+    const GeoCoord result = ecef_to_lla(pos_m);
+
+    EXPECT_TRUE(GeoCoordNear(result, expected, 1e-3));
+}
+
+// =================================================================================================
+TEST(EcefToLlaTest, MathWorksExample2)
+{
+    // https://www.mathworks.com/help/aerotbx/ug/ecef2lla.html
+    const Vector<3> pos_m {0.0, 4507609.0, 4498719.0};
+
+    const GeoCoord expected(
+        deg2rad(45.1358),
+        deg2rad(90.0),
+        999.8659
+    );
+
+    const GeoCoord result = ecef_to_lla(pos_m);
+
+    EXPECT_TRUE(GeoCoordNear(result, expected, 1e-3));
+}
+
+// =================================================================================================
+int main(int argc, char** argv)
+{
+    ::testing::GTEST_FLAG(output) = std::string("xml:") + test_reports_file;
+    ::testing::GTEST_FLAG(death_test_style) = "threadsafe";
+
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+
+}  // namespace


### PR DESCRIPTION
Created function to convert earth-centered, earth-fixed position to geodetic latitude, longitude, and altitude.

Used [THIS](https://danceswithcode.net/engineeringnotes/geodetic_to_ecef/geodetic_to_ecef.html) method.